### PR TITLE
Output readable backtraces on crashes

### DIFF
--- a/eu.usdx.UltraStarDeluxe.yaml
+++ b/eu.usdx.UltraStarDeluxe.yaml
@@ -48,6 +48,9 @@ build-options:
   append-path: /usr/lib/sdk/freepascal/bin
   env:
    - FPCDIR=/usr/lib/sdk/freepascal/fpcsrc
+  no-debuginfo-compression: true
+  cflags: -gdwarf-3
+  cxxflags: -gdwarf-3
 
 modules:
 - name: opencv

--- a/eu.usdx.UltraStarDeluxe.yaml
+++ b/eu.usdx.UltraStarDeluxe.yaml
@@ -175,9 +175,32 @@ modules:
     - patches/instructions.patch
     - patches/ldflags.patch
     - patches/debinfo.patch
+    - patches/find-debinfo.patch
   - type: shell
     commands:
 # Workaround for flathub/org.freedesktop.Sdk.Extension.freepascal#10
     - cp /usr/lib/sdk/freepascal/etc/fpc.cfg fpc.cfg
     - ln -s ../fpc.cfg src/
     - "set -- `gcc -print-file-name=crtbegin.o` ; echo -Fl${1%/*} >> fpc.cfg"
+
+- name: link-debug-data
+  buildsystem: simple
+  build-commands:
+  - mkdir -p ${FLATPAK_DEST}/lib/debug/for-freepascal
+  - ln -s ${FLATPAK_DEST}/bin/ultrastardx ${FLATPAK_DEST}/lib/debug/for-freepascal/
+  - |
+    (
+        echo ${FLATPAK_DEST}/bin/ultrastardx
+        ldd ${FLATPAK_DEST}/bin/ultrastardx | sed -n 's/.* => //;s/ ([^)]*)$//;s:^[[:space:]]*/:/:p'
+    ) | while read a ; do
+        objcopy --dump-section .gnu_debuglink=/tmp/debuglink "$a" /dev/null
+        if [ -e /tmp/debuglink ] ; then
+            l=`hexdump -e '1/2000 "%s"' /tmp/debuglink`
+            rm -f /tmp/debuglink
+            a=${a%/*}
+            case "$a" in
+            ${FLATPAK_DEST}/*)
+                ln -s ..${a#${FLATPAK_DEST}}/$l ${FLATPAK_DEST}/lib/debug/for-freepascal/
+            esac
+        fi
+    done

--- a/patches/debinfo.patch
+++ b/patches/debinfo.patch
@@ -1,19 +1,60 @@
 Free Pascal supports -gs for stabs debug info, -gw for dwarf debug info,
 and -g for the default debug info format. Optionally the dwarf version can
 be appended to -gw. GCC has far more switches to enable debugging and
-supports different levels of debug info verbosity. To keep it simple,
-let's map just -g to the Free Pascal flags.
+supports different levels of debug info verbosity.
 
 diff --git a/src/Makefile.in b/src/Makefile.in
-index f5b2b144..15f6baec 100644
+index ccbe54ac..59a5a463 100644
 --- a/src/Makefile.in
 +++ b/src/Makefile.in
-@@ -99,7 +99,7 @@ PFLAGS_EXTRA   += @PFLAGS_EXTRA@
+@@ -79,6 +79,15 @@ PINC_FLAGS := -Fi$(USDX_LIB_DIR)/JEDI-SDL/SDL/Pas
+ # Defined on debug mode
+ ENABLE_DEBUG := @ENABLE_DEBUG@
+ 
++gcc2fpc = $(if $(filter $(1),-g -g1 -g2 -g3 -ggdb -ggdb1 -ggdb2 -ggdb3),-g) \
++          $(if $(filter $(1),-gstabs -gstabs1 -gstabs2 -gstabs3),-gs) \
++          $(if $(filter $(1),-gdwarf),-gw) \
++          $(if $(filter $(1),-gdwarf-2),-gw2) \
++          $(if $(filter $(1),-gdwarf-3),-gw3) \
++          $(if $(filter $(1),-gdwarf-4 -gdwarf-5),-gw4)
++
++PFLAGS_FROM_CFLAGS := $(foreach flag,$(CFLAGS),$(call gcc2fpc,$(flag)))
++
+ # Note: 
+ #   - PFLAGS/PFLAGS_* defaults to $(PFLAGS_XYZ_DEFAULT) if not set by the user
+ #   - if PFLAGS is defined, PFLAGS_* will be ignored on "make all"
+@@ -99,15 +108,15 @@ PFLAGS_EXTRA   += @PFLAGS_EXTRA@
+ # - The stack check (-Ct) might not work with enabled threading
  # - Do we need -Coi?
  PFLAGS_BASE_DEFAULT    := -Si -Sg- -Sc- -v0Binwe
- PFLAGS_DEBUG_DEFAULT   := -Xs- -g -gl -dDEBUG_MODE
--PFLAGS_RELEASE_DEFAULT := -Xs- -O2
-+PFLAGS_RELEASE_DEFAULT := -Xs- -O2 $(filter -g,$(CFLAGS))
+-PFLAGS_DEBUG_DEFAULT   := -Xs- -g -gl -dDEBUG_MODE
++PFLAGS_DEBUG_DEFAULT   := -Xs- -g -dDEBUG_MODE
+ PFLAGS_RELEASE_DEFAULT := -Xs- -O2
  PFLAGS_EXTRA_DEFAULT   :=
  
  # Debug/Release mode flags
+ # Note that flags will overwrite previously specified flags,
+ # e.g. "-vinwe -vi-" is the same as "-vnwe"
+-PFLAGS_DEBUG_ALL   := $(PFLAGS_BASE) $(PFLAGS_DEBUG) $(PFLAGS_EXTRA)
+-PFLAGS_RELEASE_ALL := $(PFLAGS_BASE) $(PFLAGS_RELEASE) $(PFLAGS_EXTRA)
++PFLAGS_DEBUG_ALL   := $(PFLAGS_BASE) $(PFLAGS_DEBUG) $(PFLAGS_FROM_CFLAGS) $(PFLAGS_EXTRA)
++PFLAGS_RELEASE_ALL := $(PFLAGS_BASE) $(PFLAGS_RELEASE) $(PFLAGS_FROM_CFLAGS) $(PFLAGS_EXTRA)
+ 
+ # Choose default PFLAGS, depending on debug mode.
+ # Only used if PFLAGS was not set by the user.
+@@ -117,6 +126,15 @@ else
+ PFLAGS_DEFAULT := $(PFLAGS_RELEASE_ALL)
+ endif
+ 
++# If we are adding debug data, we want the rtl unit to show line numbers
++ifneq (,$(filter -g%,$(PFLAGS_DEFAULT)))
++PFLAGS_DEFAULT += -gl -OoNOSTACKFRAME
++endif
++
++ifneq (,$(filter -gw4,$(PFLAGS)))
++$(warning As of Free Pascal 3.2.2 BacktraceStrFunc does not support DWARF > v3)
++endif
++
+ ###
+ # linker and library settings
+ ###

--- a/patches/find-debinfo.patch
+++ b/patches/find-debinfo.patch
@@ -1,0 +1,22 @@
+The BacktraceStrFunc function from the Free Pascal runtime supports
+loading separate debug info, but only tries the current directory and
+the directory of the executable/library. Since USDX doesn't try to
+change the current directory at runtime, change to the directory with
+the debug data prepared by the flatpak manifest.
+
+diff --git a/src/base/UPlatformLinux.pas b/src/base/UPlatformLinux.pas
+index 90f3e23e..7a51ee9c 100644
+--- a/src/base/UPlatformLinux.pas
++++ b/src/base/UPlatformLinux.pas
+@@ -92,6 +92,11 @@ procedure TPlatformLinux.DetectLocalExecution();
+   LocalDir := GetExecutionDir();
+   LanguageDir := LocalDir.Append('languages');
+   UseLocalDirs := LanguageDir.IsDirectory and not LocalDir.IsReadonly;
++  if not UseLocalDirs then
++    try
++      chdir('/app/lib/debug/for-freepascal');
++    except
++    end;
+ end;
+ 
+ function TPlatformLinux.GetLogPath: IPath;


### PR DESCRIPTION
USDX has a built-in mechanism to catch unexpected exceptions and display backtraces. But this mechanism needs the debug data in a specific format and in a place where it is found.

With this patch backtraces decode addresses to source file and line numbers when the addresses are inside the pascal code or in any of the C/C++ libraries that are built as part of this flatpak. For C/C++ code it does not show the name of the function. That appears to be a limitation of the DWARF parser.

For libraries from the flatpak runtime, only the addresses are shown, because the function from the Free Pascal library to decode addresses neither supports compressed debug info nor DWARF > v3. With the Freedesktop SDK 24.08 the debug data is both. That's also why there is no benefit in executing `flatpak run` with `-d`. Just install eu.usdx.UltraStarDeluxe.Debug and execute USDX as before.