### PR TITLE
Fix version of ffmpeg-full extension

### DIFF
--- a/eu.usdx.UltraStarDeluxe.yaml
+++ b/eu.usdx.UltraStarDeluxe.yaml
@@ -38,7 +38,7 @@ add-extensions:
 
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: '23.08'
+    version: '24.08'
     add-ld-path: .
 
 sdk-extensions:


### PR DESCRIPTION
It has to match the SDK version.

Fixes #24

We have to wait with SDK 25.08 until flathub/org.freedesktop.Sdk.Extension.freepascal#22 has been merged.
With 25.08 we will have to use a different extension as mentioned [here](https://discourse.flathub.org/t/freedesktop-sdk-25-08-0-released/10399).